### PR TITLE
Transform instance and global variables to state and props

### DIFF
--- a/example/app/components/Clock.haml
+++ b/example/app/components/Clock.haml
@@ -30,9 +30,9 @@
   }
 
 :ruby
-  stroke = props[:stroke] || "#000"
-  fill = props[:fill] || "transparent"
-  classname = props[:class]
+  stroke = $stroke || "#000"
+  fill = $fill || "transparent"
+  classname = $class
 
 %div(class=classname)
   %svg.svg(width="100" height="100" viewBox="-100 -100 200 200" xmlns="http://www.w3.org/2000/svg")
@@ -40,13 +40,13 @@
     %g
       - x1, y1, x2 = [0, 0, 0]
       - y2 = -50
-      - style = { transform: format("rotateZ(%.5fturn)", state[:hour] / 12.0) }
+      - style = { transform: format("rotateZ(%.5fturn)", @hour / 12.0) }
       %line.hand(x1=x1 y1=y1 x2=x2 y2=y2 stroke=stroke stroke-width="6"){style:}
       - y2 = -60
-      - style = { transform: format("rotateZ(%.5fturn)", state[:hour] + state[:min] / 60.0) }
+      - style = { transform: format("rotateZ(%.5fturn)", @hour + @min / 60.0) }
       %line.hand(x1=x1 y1=y1 x2=x2 y2=y2 stroke=stroke stroke-width="3"){style:}
       - y2 = -80
-      - style = { transform: format("rotateZ(%.5fturn)", state[:hour] * 60.0 + state[:min] + state[:sec] / 60.0) }
+      - style = { transform: format("rotateZ(%.5fturn)", @hour * 60.0 + @min + @sec / 60.0) }
       %line.hand(x1=x1 y1=y1 x2=x2 y2=y2 stroke=stroke stroke-width="1"){style:}
     %circle(cx=0 cy=0 r=3 fill=stroke)
     %g

--- a/example/app/components/Form/Checkbox.haml
+++ b/example/app/components/Form/Checkbox.haml
@@ -30,12 +30,12 @@
 :ruby
   classname = [
     styles[:checkbox],
-    props[:class],
+    $class,
   ].compact.join(" ")
 
   group_classname = [
     styles.group,
-    props[:group_class],
+    $group_class,
   ].compact.join(" ")
 
   id = "checkbox-#{vnode_id}"
@@ -44,8 +44,8 @@
   %input(id=id){
     class: classname,
     type: "checkbox",
-    placeholder: props[:label],
+    placeholder: $label,
     **props.except(:label),
   }
   %label(for=id)
-    = props[:label]
+    = $label

--- a/example/app/components/Form/Input.haml
+++ b/example/app/components/Form/Input.haml
@@ -72,8 +72,8 @@
 
 .group
   %input(type="text"){
-    class: props[:class],
-    placeholder: props[:label],
+    class: $class,
+    placeholder: $label,
     **props
   }
-  %label= props[:label]
+  %label= $label

--- a/example/app/components/Form/Select.haml
+++ b/example/app/components/Form/Select.haml
@@ -49,9 +49,9 @@
 
 %div
   %select(type="text"){
-    class: props[:class],
-    placeholder: props[:label],
+    class: $class,
+    placeholder: $label,
     **props
   }
     %slot
-  %label= props[:label]
+  %label= $label

--- a/example/app/components/Layout/Header.haml
+++ b/example/app/components/Layout/Header.haml
@@ -2,7 +2,7 @@
   MaxWidth = import("/app/components/Layout/MaxWidth")
   Icon = import("/app/components/UI/Icon")
 
-%header{class: props[:class]}
+%header{class: $class}
   %MaxWidth.inner
     %h1
       %a.title(href="/" title="Start page")

--- a/example/app/components/Layout/Heading.haml
+++ b/example/app/components/Layout/Heading.haml
@@ -2,7 +2,7 @@
   # class scope
 
 :ruby
-  level = props[:level].to_i.clamp(1, 6)
+  level = $level.to_i.clamp(1, 6)
   tag = :"h#{level}"
   classname = styles[:h, tag, styles[:class]]
 

--- a/example/app/components/Layout/MaxWidth.haml
+++ b/example/app/components/Layout/MaxWidth.haml
@@ -6,8 +6,8 @@
 
 :ruby
   Mayu::VDOM.h(
-    (props[:as] || props[:tag] || :div).to_sym,
+    ($as || $tag || :div).to_sym,
     *children,
     **props,
-    class: styles[:maxWidth, props[:class]]
+    class: styles[:maxWidth, $class]
   )

--- a/example/app/components/Layout/MenuItem.haml
+++ b/example/app/components/Layout/MenuItem.haml
@@ -20,5 +20,5 @@
   }
 
 %li
-  %a{href: props[:href]}
+  %a{href: $href}
     %slot

--- a/example/app/components/Layout/Page.haml
+++ b/example/app/components/Layout/Page.haml
@@ -4,8 +4,8 @@
 
 %MaxWidth(grid)
   .page
-    = if props[:title]
-      %Heading(level=1)= props[:title]
+    = if $title
+      %Heading(level=1)= $title
 
     %slot(name="after_heading")
     .wrap

--- a/example/app/components/Markdown.haml
+++ b/example/app/components/Markdown.haml
@@ -55,7 +55,7 @@
   end
 
   def build(type, default, *children, **props, &block)
-    if elems = self.props[:elems]
+    if elems = $elems
       if elem = elems[type]
         return Mayu::VDOM.h(elem, *children, **props)
       end

--- a/example/app/components/UI/Breadcrumbs/Breadcrumbs.haml
+++ b/example/app/components/UI/Breadcrumbs/Breadcrumbs.haml
@@ -35,7 +35,7 @@
 %nav{ aria: { label: "Breadcrumbs" } }
   %MaxWidth
     %ol
-      = add_separators(props[:links]).map.with_index do |elem, i|
+      = add_separators($links).map.with_index do |elem, i|
         %li[i]
           = if elem == :sep
             %Separator

--- a/example/app/components/UI/Breadcrumbs/Link.haml
+++ b/example/app/components/UI/Breadcrumbs/Link.haml
@@ -10,4 +10,4 @@
     text-decoration: underline;
     opacity: 1;
   }
-%a{href: props[:path]}= props[:text]
+%a{href: $path}= $text

--- a/example/app/components/UI/Card.haml
+++ b/example/app/components/UI/Card.haml
@@ -7,10 +7,10 @@
     display: grid;
   }
 .card{
-  class: props[:class],
+  class: $class,
   style: {
-    :"--card-background" => props[:background] || "var(--bright)",
-    :"--card-border" => props[:border] || "#0002",
+    :"--card-background" => $background || "var(--bright)",
+    :"--card-border" => $border || "#0002",
   }
 }
   %slot

--- a/example/app/components/UI/Details.haml
+++ b/example/app/components/UI/Details.haml
@@ -20,9 +20,18 @@
 
   def handle_toggle(e)
     if e in { target: { open: true } }
-      update(loaded: true)
+      @loaded = true
     end
   end
+
+%Card{class: $class}
+  %details(ontoggle=handle_toggle open=open)
+    %summary= $summary
+    .content
+      = if @loaded
+        %slot
+      = else
+        %p Loading…
 
 :css
   details {
@@ -50,14 +59,3 @@
     margin: 0;
     padding: 0;
   }
-
-- state => open:
-
-%Card{class: props[:class]}
-  %details(ontoggle=handle_toggle open=open)
-    %summary= props[:summary]
-    .content
-      = if state[:loaded]
-        %slot
-      = unless state[:loaded]
-        %p Loading…

--- a/example/app/components/UI/Highlight.haml
+++ b/example/app/components/UI/Highlight.haml
@@ -6,8 +6,8 @@
   end
 
   def lexer
-    return unless props[:language]
-    case props[:language].to_sym
+    return unless $language
+    case $language.to_sym
     when :haml
       Rouge::Lexers::Haml.new
     when :shell

--- a/example/app/components/UI/Icon/Icon.haml
+++ b/example/app/components/UI/Icon/Icon.haml
@@ -61,21 +61,17 @@
     mask-position: 50% 50%;
   }
 :ruby
-  props => name:
-
-  url = ICONS[name] or return
-
-  aria = props[:title] ? {} : { hidden: "true" }
-
+  url = ICONS[$name] or return
+  aria = $title ? {} : { hidden: "true" }
   style = {
-    **(props[:style] || {}),
+    **($style || {}),
     __icon: "url(#{url})",
-    __icon_color: props[:color]
+    __icon_color: $color
   }.reject { _2.nil? }
 
 %i{
-  class: props[:class],
-  title: props[:title],
+  class: $class,
+  title: $title,
   style:,
   aria:,
 }

--- a/example/app/components/UI/Image.haml
+++ b/example/app/components/UI/Image.haml
@@ -1,9 +1,9 @@
 :ruby
   def inline_style
-    return {} if props[:blur] == false
+    return {} if $blur == false
 
     {
-      background_image: "url('#{props[:image].blur}')",
+      background_image: "url('#{$image.blur}')",
       background_size: "cover",
     }
   end
@@ -15,18 +15,13 @@
   }
 
 :ruby
-  image = props.fetch(:image)
+  image = $image or return
 
-  loading = props[:lazy] && "lazy"
-  decoding = props.fetch(:decoding, "async")
+  loading = $lazy && "lazy"
+  decoding = $decoding || "async"
+  alt = $alt or Console.logger.warn(self, "Missing alt-attribute!")
 
-  alt = props.fetch(:alt) do
-    Console.logger.warn(self, "Missing alt-attribute!")
-  end
-
-  classname = props[:class]
-
-%img(style=inline_style loading=loading decoding=decoding alt=alt class=classname){
+%img(style=inline_style loading=loading decoding=decoding alt=alt class=$class){
   src: image.src,
   sizes: image.sizes,
   srcset: image.srcset,

--- a/example/app/components/UI/Link.haml
+++ b/example/app/components/UI/Link.haml
@@ -10,6 +10,6 @@
     text-decoration: underline;
   }
 :ruby
-  style = props[:color] && { __link_color: props[:color] }
+  style = $color && { __link_color: $color }
 %a(style=style){**props.except(:color)}
   %slot

--- a/example/app/components/UI/Tabs.haml
+++ b/example/app/components/UI/Tabs.haml
@@ -7,20 +7,14 @@
   def handle_change(e)
     e => { target: { value: }}
 
-    update do |state|
-      {
-        active: value,
-        enabled: [*state[:enabled], value].uniq
-      }
-    end
+    @active = value
+    @enabled = [*@enabled, value].uniq
   end
 
   def handle_enable(e)
     e => { target: { value: }}
 
-    update do |state|
-      { enabled: [*state[:enabled], value].uniq }
-    end
+    @enabled = [*@enabled, value].uniq
   end
 
   private
@@ -28,6 +22,32 @@
   def id(*args)
     [:id, *args, vnode_id].flatten.join("-")
   end
+
+.tabs
+  .tablist(role="tablist")
+    = children.slots.keys.map.with_index do |name, i|
+      - handle_enable = @enabled.include?(name) ? nil : handler(:handle_enable)
+      %button[name](value=name onclick=handle_change role="tab" tabindex="0"){
+        id: id(:tab, i),
+        onmouseenter: handle_enable,
+        ontouchstart: handle_enable,
+        aria: {
+          selected: (name == @active).to_s,
+          controls: id(:panel, i)
+        }
+      }= name
+
+  = children.slots.keys.map.with_index do |name, i|
+    .panel(role="tabpanel" tabindex="0"){
+      id: id(:panel, i),
+      hidden: name != @active,
+      aria: {
+        labelledby: id(:tab, i),
+        expanded: (name == @active).to_s,
+      }
+    }
+      = if @enabled.include?(name)
+        %slot(name=name)
 
 :css
   .tabs {
@@ -75,34 +95,3 @@
   .panel {
     margin: 1em;
   }
-
-
-:ruby
-  state => active:, enabled:
-  names = children.slots.keys
-
-.tabs
-  .tablist(role="tablist")
-    = names.map.with_index do |name, i|
-      - handle_enable = enabled.include?(name) ? nil : handler(:handle_enable)
-      %button[name](value=name onclick=handle_change role="tab" tabindex="0"){
-        id: id(:tab, i),
-        onmouseenter: handle_enable,
-        ontouchstart: handle_enable,
-        aria: {
-          selected: (name == active).to_s,
-          controls: id(:panel, i)
-        }
-      }= name
-
-  = names.map.with_index do |name, i|
-    .panel(role="tabpanel" tabindex="0"){
-      id: id(:panel, i),
-      hidden: name != active,
-      aria: {
-        labelledby: id(:tab, i),
-        expanded: (name == active).to_s,
-      }
-    }
-      = if enabled.include?(name)
-        %slot(name=name)

--- a/example/app/components/UI/YouTubeVideo.haml
+++ b/example/app/components/UI/YouTubeVideo.haml
@@ -11,13 +11,12 @@
     width: 100%;
     height: 100%;
   }
-:ruby
-  props => video_id:
+
 .wrapper
   %iframe(allowfullscreen){
     allow: "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture",
     frameborder: 0,
     loading: "lazy",
-    title: props[:title] || "YouTube video player",
-    src: "https://www.youtube.com/embed/#{video_id}",
+    title: $title || "YouTube video player",
+    src: "https://www.youtube.com/embed/#{$video_id}",
   }

--- a/example/app/pages/Blurb.haml
+++ b/example/app/pages/Blurb.haml
@@ -25,10 +25,8 @@
     text-align: left;
     font-size: .9em;
   }
-:ruby
-  props => icon:, title:
 %article
-  %Icon(name=icon){color: props[:color] || "var(--dark)"}
+  %Icon(name=$icon){color: $color || "var(--dark)"}
   .content
-    %h3= title
+    %h3= $title
     %slot

--- a/example/app/pages/Counter.haml
+++ b/example/app/pages/Counter.haml
@@ -5,7 +5,7 @@
     count: initial_value
   }
 
-  def decrement_disabled = state[:count].zero?
+  def decrement_disabled = @count.zero?
 
   def handle_decrement
     update do |state|

--- a/example/app/pages/Counter.haml
+++ b/example/app/pages/Counter.haml
@@ -5,21 +5,9 @@
     count: initial_value
   }
 
+  def handle_increment = @count += 1
+  def handle_decrement = @count -= 1
   def decrement_disabled = @count.zero?
-
-  def handle_decrement
-    update do |state|
-      count = [0, state[:count] - 1].max
-      { count: }
-    end
-  end
-
-  def handle_increment
-    update do |state|
-      count = state[:count] + 1
-      { count: }
-    end
-  end
 
 %Card.card
   %article
@@ -80,4 +68,3 @@
     filter: grayscale(100%);
     box-shadow: rgba(0, 0, 0, 0.24) 0px 2px 4px;
   }
-

--- a/example/app/pages/FeatureThing.haml
+++ b/example/app/pages/FeatureThing.haml
@@ -18,7 +18,7 @@
       sleep 2.2
 
       update do |state|
-        { index: state[:index].succ % ITEMS.size }
+        { index: @index.succ % ITEMS.size }
       end
     end
   end
@@ -34,4 +34,4 @@
 
 %ul
   = ITEMS.map.with_index do |item, index|
-    %li{class: { active: index == state[:index] }}= item
+    %li{class: { active: index == @index }}= item

--- a/example/app/pages/Intro.haml
+++ b/example/app/pages/Intro.haml
@@ -11,22 +11,22 @@
   def mount
     loop do
       sleep 15
-      update(angle: rand)
+      @angle = rand
 
       WORDS.length.times do |i|
-        update(word: i)
+        @word = i
         sleep 0.5
       end
 
-      update(word: nil)
+      @word = nil
     end
   end
 
-.intro{style: { "--angle": "#{state[:angle] * 2}turn" }}
+.intro{style: { "--angle": "#{@angle * 2}turn" }}
   %MaxWidth
     .inner
       %h1
         Reactive Server-Side component-based VirtualDOM framework for Ruby
       %h2
         = WORDS.map.with_index do |word, i|
-          %span{class: { active: i == state[:word] }}= word
+          %span{class: { active: i == @word }}= word

--- a/example/app/pages/Section.haml
+++ b/example/app/pages/Section.haml
@@ -6,6 +6,6 @@
       rgba(0, 0, 0, 0.3) 0px 18px 36px -18px inset;
     padding: 4em 0;
   }
-%section{class: props[:class]}
+%section(class=$class)
   %MaxWidth
     %slot

--- a/example/app/pages/demos/ButtonGame.haml
+++ b/example/app/pages/demos/ButtonGame.haml
@@ -11,11 +11,9 @@
     { x: 0, y: 0, count: 0 }
 
   def handle_click
-    update(
-      count: state[:count].succ,
-      x: (rand * 2 - 1) * 200,
-      y: (rand * 2 - 1) * 200,
-    )
+    @count += 1
+    @x = (rand * 2 - 1) * 200
+    @y = (rand * 2 - 1) * 200
   end
 
 :css
@@ -29,4 +27,4 @@
   style = { transform: }
 
 %button(style=style onclick=handle_click)
-  = MESSAGES[state[:count] % MESSAGES.size]
+  = MESSAGES[@count % MESSAGES.size]

--- a/example/app/pages/demos/events/page.haml
+++ b/example/app/pages/demos/events/page.haml
@@ -9,11 +9,8 @@
   }
 
   def handle_alert
-    helpers.alert("Hello world\nCount: #{state[:count]}")
-
-    update do |state|
-      { count: state[:count] + 1 }
-    end
+    helpers.alert("Hello world\nCount: #{@count}")
+    @count += 1
   end
 
 %article

--- a/example/app/pages/demos/exceptions/page.haml
+++ b/example/app/pages/demos/exceptions/page.haml
@@ -11,9 +11,7 @@
   def handle_click(e) =
     case e
     in { target: { name: "increment" } }
-      update do |state|
-        { count: state[:count] + 1 }
-      end
+      @count += 1
     end
 
 %article
@@ -24,7 +22,7 @@
       Issue for implementing error boundaries
   %p
     Count:
-    %output<= state[:count]
+    %output<= @count
   %p
     %button(onclick=handle_click name="increment") Increment
     %button(onclick=handle_click name="error") Error

--- a/example/app/pages/demos/form/TransferList.haml
+++ b/example/app/pages/demos/form/TransferList.haml
@@ -20,29 +20,21 @@
   end
 
   def handle_submit(e)
-    update do |state|
-      case e
-      in { submitter: { name: "action", value: "move_all_left" } }
-        { left: state[:left] + state[:right], right: [] }
-      in { submitter: { name: "action", value: "move_all_right" } }
-        { left: [], right: state[:right] + state[:left] }
-      in { submitter: { name: "action", value: "move_selected_left" }, target: { formData: } }
-        selected = get_selected(formData, "right-")
-
-        {
-          left: state[:left].union(selected),
-          right: state[:right].difference(selected),
-        }
-      in { submitter: { name: "action", value: "move_selected_right" }, target: { formData: } }
-        selected = get_selected(formData, "left-")
-
-        {
-          left: state[:left].difference(selected),
-          right: state[:right].union(selected),
-        }
-      else
-        {}
-      end
+    case e
+    in { submitter: { name: "action", value: "move_all_left" } }
+      @left += @right
+      @right = []
+    in { submitter: { name: "action", value: "move_all_right" } }
+      @right += @left
+      @left = []
+    in { submitter: { name: "action", value: "move_selected_left" }, target: { formData: } }
+      selected = get_selected(formData, "right-")
+      @left = @left.union(selected)
+      @right = @right.difference(selected)
+    in { submitter: { name: "action", value: "move_selected_right" }, target: { formData: } }
+      selected = get_selected(formData, "left-")
+      @left = @left.difference(selected)
+      @right = @right.difference(selected)
     end
   end
 
@@ -50,7 +42,7 @@
   %legend Transfer list
   %form{on_submit: handler(:handle_submit)}
     %ul
-      = state[:left].map do |item|
+      = @left.map do |item|
         %li[item]
           %Checkbox{
             label: ITEMS[item],
@@ -65,7 +57,7 @@
       %button(type="submit" name="action" value="move_selected_right" title="Move selected right") ⟩
 
     %ul
-      = state[:right].map do |item|
+      = @right.map do |item|
         %li[item]
           %Checkbox{
             label: ITEMS[item],

--- a/example/app/pages/demos/life/Cell.haml
+++ b/example/app/pages/demos/life/Cell.haml
@@ -1,11 +1,11 @@
 :ruby
   def should_update?(next_props, _next_state)
     case
-    when props[:alive] != next_props[:alive]
+    when $alive != next_props[:alive]
       true
-    when props[:x] != next_props[:x]
+    when $x != next_props[:x]
       true
-    when props[:y] != next_props[:y]
+    when $y != next_props[:y]
       true
     else
       false

--- a/example/app/pages/demos/life/GameGrid.haml
+++ b/example/app/pages/demos/life/GameGrid.haml
@@ -20,10 +20,8 @@
   }
 
 :ruby
-  props => grid:, ondraw:
-
 .grid
-  = props[:grid].map.with_index do |row, y|
+  = $grid.map.with_index do |row, y|
     .row[y]
       = row.map.with_index do |alive, x|
-        %Cell["#{x}.#{y}"]{ondraw:, alive:, x:, y:}
+        %Cell["#{x}.#{y}"]{ondraw: $ondraw, alive:, x:, y:}

--- a/example/app/pages/demos/life/page.haml
+++ b/example/app/pages/demos/life/page.haml
@@ -43,9 +43,9 @@
 
   def mount
     loop do
-      if state[:running]
+      if @running
         handle_step
-        sleep 1.0 / state[:fps]
+        sleep 1.0 / @fps
       else
         sleep 0.5
       end
@@ -86,7 +86,7 @@
   def set_cell_value(x, y, value)
     update do |state|
       {
-        grid: state[:grid].dup.tap do |grid|
+        grid: @grid.dup.tap do |grid|
           grid[y] = grid[y].dup.tap { |row| row[x] = value }
         end
       }
@@ -177,9 +177,6 @@
     gap: 1em;
   }
 
-:ruby
-  state => grid:, running:
-
 %article
   %Heading(level=2) Game of life
 
@@ -196,22 +193,22 @@
       %Button(onclick=handle_randomize) Randomize
       %Button(onclick=handle_step disabled=running) Step
       %Button(onclick=handle_toggle_running){
-        color: running ? "var(--red)" : "var(--green)"
-      }= running ? "Stop" : "Start"
+        color: @running ? "var(--red)" : "var(--green)"
+      }= @running ? "Stop" : "Start"
     -#
       %div
         %label(for="grid-width") Grid width
         %br
-        %input(id="grid-width" type="range" min=MIN_SIZE max=MAX_SIZE step=1 oninput=handle_change_width){value: state[:width]}
-        %output= state[:width]
+        %input(id="grid-width" type="range" min=MIN_SIZE max=MAX_SIZE step=1 oninput=handle_change_width){value: @width}
+        %output= @width
       %div
         %label(for="grid-height") Grid height
         %br
-        %input(id="grid-height" type="range" min=MIN_SIZE max=MAX_SIZE step=1 oninput=handle_change_height){value: state[:height]}
-        %output= state[:height]
+        %input(id="grid-height" type="range" min=MIN_SIZE max=MAX_SIZE step=1 oninput=handle_change_height){value: @height}
+        %output= @height
       %div
         %label(for="game-fps") Frames per second
         %br
-        %input(id="game-fps" type="range" min=MIN_FPS max=MAX_FPS step=1 oninput=handle_change_fps){value: state[:fps]}
-        %output= state[:fps]
-  %GameGrid(grid=grid ondraw=handle_draw)
+        %input(id="game-fps" type="range" min=MIN_FPS max=MAX_FPS step=1 oninput=handle_change_fps){value: @fps}
+        %output= @fps
+  %GameGrid(grid=@grid ondraw=handle_draw)

--- a/example/app/pages/demos/pokemon/Filter.haml
+++ b/example/app/pages/demos/pokemon/Filter.haml
@@ -12,26 +12,41 @@
     suggestions: [],
   }
 
-  def handle_open
-    update(open: true)
-  end
-
-  def handle_close
-    update(open: false)
-  end
+  def handle_open = @open = true
+  def handle_close = @open = false
 
   def mount
-    @fuzzymatch = FuzzyMatch.new(props[:results], read: :name)
+    instance_variable_set(:@fuzzymatch, FuzzyMatch.new($results, read: :name))
   end
 
   def handle_change(e)
     e => { target: { value: } }
 
-    update(
-      value:,
-      suggestions: @fuzzymatch.find_all(value).first(10)
-    )
+    @value = value
+    @suggestions =
+      instance_variable_get(:@fuzzymatch)
+      .find_all(value)
+      .first(10)
   end
+
+%div
+  %Button(onclick=handle_open)
+    %Icon(name="filter")>
+    Filter
+  %dialog(onclose=handle_close){open: @open}
+    %form(method="dialog")
+      %Fieldset
+        %legend Filter
+        %Input(label="Name" oninput=handle_change onchange=handle_change autocomplete="off")
+        %Button Close
+        .results
+          %ul
+            = @suggestions.map do |result|
+              - id = result[:url].split("/").last.to_i
+              %li
+                %a(href="/demos/pokemon/#{id}")
+                  = result[:name]
+
 :css
   .results {
     position: relative;
@@ -70,21 +85,3 @@
   dialog::backdrop {
     backdrop-filter: brightness(50%) blur(5px);
   }
-
-%div
-  %Button(onclick=handle_open)
-    %Icon(name="filter")>
-    Filter
-  %dialog(onclose=handle_close){open: state[:open]}
-    %form(method="dialog")
-      %Fieldset
-        %legend Filter
-        %Input(label="Name" oninput=handle_change onchange=handle_change autocomplete="off")
-        %Button Close
-        .results
-          %ul
-            = state[:suggestions].map do |result|
-              - id = result[:url].split("/").last.to_i
-              %li
-                %a(href="/demos/pokemon/#{id}")
-                  = result[:name]

--- a/example/app/pages/demos/pokemon/Pagination.haml
+++ b/example/app/pages/demos/pokemon/Pagination.haml
@@ -18,25 +18,19 @@
   end
 
 :ruby
-  props => {
-    page:,
-    per_page:,
-    total_pages:,
-  }
-
-  prev_page_link = page > 1 && "?page=#{page.pred}"
-  next_page_link = page <= props[:total_pages] && "?page=#{page.succ}"
+  prev_page_link = $page > 1 && "?page=#{$page.pred}"
+  next_page_link = $page <= $total_pages && "?page=#{$page.succ}"
 
   pages =
     pagination_window(
-      current_page: page,
-      total_pages: props[:total_pages].succ,
-      window_size: props[:window_size] || 5,
+      current_page: $page,
+      total_pages: $total_pages.succ,
+      window_size: $window_size || 5,
     )
 
 %Fieldset
   %legend
-    Page #{page} of #{total_pages.succ}, showing #{per_page} per page
+    Page #{$page} of #{$total_pages.succ}, showing #{$per_page} per page
 
   .wrap
     %nav.buttons(aria-label="pagination")
@@ -44,18 +38,18 @@
         Previous page
 
       %ul.pages
-        = pages.map do |num|
-          %li[num]
+        = pages.map do |page|
+          %li[page]
             %a.page{
-              href: "?page=#{num}",
-              aria: { current: page == num && "page" }
-            }= num
+              href: "?page=#{page}",
+              aria: { current: $page == page && "page" }
+            }= page
 
       %a.button(href=next_page_link rel="prev")
         Next page
 
     .per-page
       Per page:
-      %select(value=per_page){on_change: props[:on_change_per_page]}<
-        = [20, 40, 80].map do |num|
-          %option[num](value=num)= num
+      %select(value=per_page){on_change: $on_change_per_page}<
+        = [20, 40, 80].map do |value|
+          %option[value]{value:}= value

--- a/example/app/pages/demos/todo/page.haml
+++ b/example/app/pages/demos/todo/page.haml
@@ -13,105 +13,83 @@
   def handle_submit(e)
     e => { target: { formData: { new_todo: String => description } } }
 
-    update do |items:, form_key:|
-      {
-        items: [
-          { id: Nanoid.generate(), description: },
-          *items,
-        ],
-        form_key: form_key.succ,
-        editing: nil,
-      }
-    end
+    @items = [
+      { id: Nanoid.generate(), description: },
+      *@items,
+    ]
+
+    @form_key = @form_key.succ
+    @editing = nil
   end
 
   def handle_set_filter(e)
     e => { target: { name: } }
-    update(filter: name, editing: nil)
+    @filter = name
+    @diting = nil
   end
 
   def handle_dblclick(e)
     e => { currentTarget: { id: } }
-    update(editing: id)
+    @editing = id
   end
 
   def handle_update(e)
     e => { currentTarget: { id:, formData: { description: } } }
 
-    update do |items:|
-      {
-        editing: nil,
-        items: items.map { |item|
-          if item[:id] == id
-            { **item, description:}
-          else
-            item
-          end
-        }
-      }
+    @editing = nil
+    @items = @items.map do |item|
+      if item[:id] == id
+        { **item, description:}
+      else
+        item
+      end
     end
   end
 
   def handle_check(e)
     e => { currentTarget: { name: id, checked: completed } }
 
-    update do |items:|
-      {
-        editing: nil,
-        items: items.map { |item|
-          if item[:id] == id
-            { **item, completed: }
-          else
-            item
-          end
-        }
-      }
+    @editing = nil
+    @items = @items.map do |item|
+      if item[:id] == id
+        { **item, completed: }
+      else
+        item
+      end
     end
   end
 
   def handle_delete(e)
     e => { currentTarget: { name: id } }
 
-    update do |items:|
-      {
-        editing: nil,
-        items: items.reject { |item| item[:id] == id }
-      }
-    end
+    @editing = nil
+    @items = @items.reject { |item| item[:id] == id }
   end
 
   def handle_toggle_all(e)
     e => { target: { checked: completed } }
 
-    update do |items:|
-      {
-        editing: nil,
-        items: items.map do |item|
-          { **item, completed: }
-        end
-      }
+    @editing = nil
+    @items = @items.map do |item|
+      { **item, completed: }
     end
   end
 
   def handle_clear_completed
-    update do |items:|
-      {
-        editing: nil,
-        items: items.reject { _1[:completed] }
-      }
-    end
+    @editing = nil
+    @items = @items.reject { _1[:completed] }
   end
 
   private
 
-  def get_filtered_items(filter = state[:filter])
+  def get_filtered_items(filter = @filter)
     case filter
     in "all"
-      state[:items]
+      @items
     in "active"
-      state[:items].select { !_1[:completed] }
+      @items.select { !_1[:completed] }
     in "completed"
-      state[:items].select { _1[:completed] }
+      @items.select { _1[:completed] }
     end
   end
 
@@ -128,8 +106,8 @@
   end
 
   def toggle_checkbox_state
-    completed_count = state[:items].count { _1[:completed] }
-    remaining_count = state[:items].count { !_1[:completed] }
+    completed_count = @items.count { _1[:completed] }
+    remaining_count = @items.count { !_1[:completed] }
 
     if completed_count == 0
       { checked: false, indeterminate: false }
@@ -141,6 +119,50 @@
       end
     end
   end
+
+%article
+  %Heading(level=2) Todo App
+  %p
+    This is an implementation of the classic
+    %Link(href="https://todomvc.com/" target="_blank")< TodoMVC app
+    \.
+  %Card
+    .header
+      %form.form(onsubmit=handle_submit autocomplete="off")[@form_key]
+        %input.toggle-all(type="checkbox" onchange=handle_toggle_all){**toggle_checkbox_state}
+        %input.input(required autofocus name="new_todo" placeholder="What needs to be done?" value="")
+    .main
+      %ul
+        = get_filtered_items.map do |item|
+          %li[item[:id]]
+            = if @editing == item[:id]
+              %form.edit(onsubmit=handle_update autocomplete="off"){id: item[:id]}
+                %input.input(type="text" name="description" autofocus onfocus="event.target.select()" required){
+                  initial_value: item[:description]
+                }
+            = unless @editing == item[:id]
+              .row
+                %input.checkbox(type="checkbox" onchange=handle_check){
+                  name: item[:id],
+                  checked: item[:completed],
+                }
+                %p.description(ondblclick=handle_dblclick){
+                  id: item[:id],
+                  class: { completed: item[:completed] },
+                }= item[:description]
+                %button.delete-button(onclick=handle_delete){name: item[:id]}
+    .footer
+      .footer-grid
+        .items-left #{pluralize(get_filtered_items("active").size, "item", "items")} left
+        .filter
+          = %w[all active completed].map do |name|
+            %button.filter-button(onclick=handle_set_filter name=name title="Show #{name} items"){
+              aria: { current: (@filter == name).to_s }
+            }= name.capitalize
+        .clear-completed
+          - completed = get_filtered_items("completed")
+          = if completed.length.nonzero?
+            %button.clear-button(onclick=handle_clear_completed) Clear completed
 
 :css
   .header {
@@ -288,47 +310,3 @@
   .clear-completed {
     text-align: right;
   }
-
-%article
-  %Heading(level=2) Todo App
-  %p
-    This is an implementation of the classic
-    %Link(href="https://todomvc.com/" target="_blank")< TodoMVC app
-    \.
-  %Card
-    .header
-      %form.form(onsubmit=handle_submit autocomplete="off")[state[:form_key]]
-        %input.toggle-all(type="checkbox" onchange=handle_toggle_all){**toggle_checkbox_state}
-        %input.input(required autofocus name="new_todo" placeholder="What needs to be done?" value="")
-    .main
-      %ul
-        = get_filtered_items.map do |item|
-          %li[item[:id]]
-            = if state[:editing] == item[:id]
-              %form.edit(onsubmit=handle_update autocomplete="off"){id: item[:id]}
-                %input.input(type="text" name="description" autofocus onfocus="event.target.select()" required){
-                  initial_value: item[:description]
-                }
-            = unless state[:editing] == item[:id]
-              .row
-                %input.checkbox(type="checkbox" onchange=handle_check){
-                  name: item[:id],
-                  checked: item[:completed],
-                }
-                %p.description(ondblclick=handle_dblclick){
-                  id: item[:id],
-                  class: { completed: item[:completed] },
-                }= item[:description]
-                %button.delete-button(onclick=handle_delete){name: item[:id]}
-    .footer
-      .footer-grid
-        .items-left #{pluralize(get_filtered_items("active").size, "item", "items")} left
-        .filter
-          = %w[all active completed].map do |name|
-            %button.filter-button(onclick=handle_set_filter name=name title="Show #{name} items"){
-              aria: { current: (state[:filter] == name).to_s }
-            }= name.capitalize
-        .clear-completed
-          - completed = get_filtered_items("completed")
-          = if completed.length.nonzero?
-            %button.clear-button(onclick=handle_clear_completed) Clear completed

--- a/example/app/pages/demos/tree/Directory.haml
+++ b/example/app/pages/demos/tree/Directory.haml
@@ -9,22 +9,22 @@
   }
 
   def mount
-    if state[:open]
+    if @open
       update(entries: load_entries)
     end
   end
 
   def should_update?(next_props, next_state)
-    state[:open] != next_state[:open]
+    @open != next_state[:open]
   end
 
   def handle_toggle
-    update do |state|
-      open = !state[:open]
-      entries = state[:entries] || (open && load_entries)
-      { open:, entries: }
-    end
+    open = !@open
+    entries = @entries || (open && load_entries)
+    { open:, entries: }
   end
+
+  def icon = @open ? "folder-open" : "folder"
 
   private
 
@@ -65,20 +65,17 @@
     text-decoration: underline;
     cursor: pointer;
   }
-:ruby
-  icon = state[:open] ? "folder-open" : "folder"
-
 %div
   %Name(icon=icon color="var(--blue)")
     %button(type="button" onclick=handle_toggle)
-      #{File.basename(props[:path])}/
+      #{File.basename($path)}/
 
-  = if state[:open]
-    = if entries = state[:entries]
+  = if @open
+    = if entries = @entries
       %ul
         = entries[:directories]&.map do |path|
           %li[path]
-            %Self{root: props[:root], path:}
+            %Self{root: $root, path:}
         = entries[:files]&.map do |path|
           %li[path]
             %FileEntry{path:}

--- a/example/app/pages/demos/tree/FileEntry.haml
+++ b/example/app/pages/demos/tree/FileEntry.haml
@@ -3,7 +3,7 @@
   Name = import("./Name")
 
   def icon
-    case File.extname(props[:path])
+    case File.extname($path)
     in ".haml" | ".css" | ".rb"
       "file-code"
     in ".md"
@@ -25,8 +25,7 @@
   }
 
 :ruby
-  props => path:
-  href = "?file=#{path}"
+  href = "?file=#{$path}"
 
 %Name(icon=icon)
-  %a(href=href)= File.basename(path)
+  %a(href=href)= File.basename($path)

--- a/example/app/pages/demos/tree/Name.haml
+++ b/example/app/pages/demos/tree/Name.haml
@@ -1,5 +1,7 @@
 :ruby
   Icon = import("/app/components/UI/Icon")
+
+  def color = $color || "var(--dark)"
 :css
   label {
     display: inline-flex;
@@ -8,9 +10,6 @@
     padding: 0;
     gap: .5em;
   }
-:ruby
-  props => { icon: }
-  color = props[:color] || "var(--dark)"
-%label{**props}
-  %Icon(name=icon color=color)
+%label{**props.except(:color, :icon)}
+  %Icon(name=$icon color=color)
   %slot

--- a/example/app/pages/docs/Details.haml
+++ b/example/app/pages/docs/Details.haml
@@ -32,6 +32,6 @@
     transform: translateX(.5em) rotateZ(.5turn);
   }
 
-%details{open: props[:open]}
-  %summary= props[:summary]
+%details{open: $open}
+  %summary= $summary
   %slot

--- a/example/app/pages/docs/data-fetching/Pokemon.haml
+++ b/example/app/pages/docs/data-fetching/Pokemon.haml
@@ -8,11 +8,10 @@
 
   def mount
     sleep 1
-    res = helpers.fetch("https://pokeapi.co/api/v2/pokemon/#{props[:id]}")
-    result = res.json(symbolize_names: true)
-    update(result:)
+    res = helpers.fetch("https://pokeapi.co/api/v2/pokemon/#{$id}")
+    @result = res.json(symbolize_names: true)
   rescue => e
-    update(error: e.message)
+    @error = e.message
   end
 
 %div
@@ -22,4 +21,4 @@
   = in { result: Hash }
     %pre= JSON.pretty_generate(result)
   = else
-    %p Loading Pokémon with id #{props[:id]}…
+    %p Loading Pokémon with id #{$id}…

--- a/example/app/pages/docs/state/page.haml
+++ b/example/app/pages/docs/state/page.haml
@@ -36,15 +36,19 @@
       If you don't need to read state when updating, you can do this:
 
       ```ruby
-      update(count: 0)
+      update(count: 0) # old syntax
+      @count = 0 # new syntax
       ```
 
       If you need to read state, you can get the entire state object:
 
       ```ruby
+      # old syntax
       update do |state|
         { count: state[:count] + 1 }
       end
+      # new syntax
+      @count += 1
       ```
 
       Or you could extract just the keys you are interested in:
@@ -58,8 +62,10 @@
       You can also use default values:
 
       ```ruby
+      # old syntax
       update do |count: 0|
         { count: count + 1 }
       end
+      # new syntax
+      @count = (@count || 0) + 1
       ```
-

--- a/example/app/pages/docs/syntax/page.haml
+++ b/example/app/pages/docs/syntax/page.haml
@@ -86,9 +86,9 @@
         def handle_click(event) =
           case event
           in { target: { name: "increment" } }
-            update { |state| { count: state[:count] + 1 } }
+            @state += 1
           in { target: { name: "decrement" } }
-            update { |state| { count: state[:count] - 1 } }
+            @state -= 1
           end
       - state => count:
       %div
@@ -109,9 +109,9 @@
           clicked: false
         }
         def handle_click(event)
-          update(clicked: true)
+          @clicked = true
         end
-      = return if state[:clicked]
+      = return if @clicked
         %p You clicked the button.
       %button(onclick=handle_click) Click me
       ```
@@ -119,7 +119,7 @@
       You can also use `return unless`.
 
       ```haml
-      = return unless props[:data]
+      = return unless $data
         %p Loading…
-      %pre= props[:data]
+      %pre= $data
       ```


### PR DESCRIPTION
Transform `@foo` into `self.state[:foo]` and `@bar` into `self.state[:bar]`, also wrap `@foo = 123` within `self.update { self.state[:foo] = 123 }`

Instance variables and global variables aren't really needed in components.
State needs to be managed, so better use this syntax. 

Not sure if it would be a good idea to keep the [globals related to regexps](https://ruby-doc.org/3.2.0/globals_rdoc.html)