### PR TITLE
Two way diff

### DIFF
--- a/example/app/pages/demos/layout.haml
+++ b/example/app/pages/demos/layout.haml
@@ -15,6 +15,7 @@
     "/demos/exceptions" => "Exceptions",
     "/demos/life" => "Game of life",
     "/demos/events" => "Events",
+    "/demos/sorting" => "Sorting",
   }
 
   def breadcrumb_links

--- a/example/app/pages/demos/sorting/page.haml
+++ b/example/app/pages/demos/sorting/page.haml
@@ -1,0 +1,94 @@
+:ruby
+  Heading = import("/app/components/Layout/Heading")
+  Highlight = import("/app/components/UI/Highlight")
+  Card = import("/app/components/UI/Card")
+  Details = import("/app/components/UI/Details")
+
+  def self.get_initial_state(**) = {
+    items: []
+  }
+
+  def handle_add
+    update do |state|
+      { items: [*state[:items], *Array.new(5) { SecureRandom.alphanumeric(5) }] }
+    end
+  end
+
+  def handle_remove
+    update do |state|
+      { items: state[:items].reject { rand(3).zero? } }
+    end
+  end
+
+  def handle_shuffle
+    update do |state|
+      { items: state[:items].shuffle }
+    end
+  end
+
+  def handle_shuffle_slices
+    update do |state|
+      { items: state[:items].each_slice(5).to_a.shuffle.flatten }
+    end
+  end
+
+  def handle_sort
+    update do |state|
+      { items: state[:items].sort }
+    end
+  end
+
+  def handle_sort_by_color
+    update do |state|
+      { items: state[:items].sort_by { color(_1) } }
+    end
+  end
+
+  def color(str)
+    Digest::SHA256.digest(str).unpack("I").first % 360
+  end
+
+%article
+  %Heading(level=2)
+    Sorting
+    %span< (#{state[:items].size} items)
+  %div
+    %button(onclick=handle_add) Add items
+    %button(onclick=handle_remove) Remove items
+    %button(onclick=handle_shuffle) Shuffle items
+    %button(onclick=handle_shuffle_slices) Shuffle slices
+    %button(onclick=handle_sort) Sort
+    %button(onclick=handle_sort_by_color) Sort by color
+  .flex
+    %pre= state[:items].join("\n")
+    %ul
+      = state[:items].map do |item|
+        %li{style: { __color: color(item) }}
+          = item
+:css
+  .flex {
+    display: flex;
+    gap: 1em;
+  }
+
+  pre {
+    line-height: 2em;
+  }
+
+  ul {
+    display: grid;
+    list-style-type: none;
+    padding: 0;
+    flex: 1 1 5em;
+    gap: 1px;
+  }
+
+  li {
+    border: 1px solid #0003;
+    border-radius: 3px;
+    margin: 0;
+    padding: 0 .5em;
+    background: hsl(var(--color), 50%, 70%);
+    color: #000;
+    line-height: 2em;
+  }

--- a/lib/mayu/utils.rb
+++ b/lib/mayu/utils.rb
@@ -4,6 +4,18 @@ module Mayu
   module Utils
     extend T::Sig
 
+    sig { params(unit: Symbol).returns(Float) }
+    def self.monotonic_now(unit = :float_millisecond)
+      Process.clock_gettime(Process::CLOCK_MONOTONIC).to_f
+    end
+
+    sig { params(unit: Symbol, block: T.proc.void).returns(Float) }
+    def self.measure_time(unit = :float_millisecond, &block)
+      start = monotonic_now
+      yield
+      monotonic_now - start
+    end
+
     sig do
       params(
         hash: T::Hash[T.untyped, T.untyped],

--- a/lib/mayu/utils.rb
+++ b/lib/mayu/utils.rb
@@ -6,7 +6,7 @@ module Mayu
 
     sig { params(unit: Symbol).returns(Float) }
     def self.monotonic_now(unit = :float_millisecond)
-      Process.clock_gettime(Process::CLOCK_MONOTONIC).to_f
+      Process.clock_gettime(Process::CLOCK_MONOTONIC, unit).to_f
     end
 
     sig { params(unit: Symbol, block: T.proc.void).returns(Float) }

--- a/lib/mayu/vdom/interfaces.rb
+++ b/lib/mayu/vdom/interfaces.rb
@@ -24,8 +24,22 @@ module Mayu
         def action(type, payload)
         end
 
-        sig { params(vnode: VNode).void }
+        sig { overridable.params(vnode: T.untyped).void }
         def enqueue_update!(vnode)
+        end
+      end
+
+      module VNode
+        extend T::Sig
+        extend T::Helpers
+        abstract!
+
+        sig { abstract.returns(String) }
+        def id
+        end
+
+        sig { abstract.returns(Descriptor) }
+        def descriptor
         end
       end
 

--- a/lib/mayu/vdom/interfaces.rb
+++ b/lib/mayu/vdom/interfaces.rb
@@ -131,7 +131,7 @@ module Mayu
         # https://ruby-doc.org/3.2.0/Hash.html#class-Hash-label-User-Defined+Hash+Keys
         sig { overridable.returns(Integer) }
         def hash
-          [type, props, key, type == :input && props[:type]].hash
+          [type, slot, key, type == :input && props[:type]].hash
         end
 
         ##

--- a/lib/mayu/vdom/reconciliation.rb
+++ b/lib/mayu/vdom/reconciliation.rb
@@ -1,102 +1,193 @@
-# typed: strict
+# typed: true
 # frozen_string_literal: true
 
 require_relative "interfaces"
-require_relative "indexes"
 
 module Mayu
   module VDOM
     module Reconciliation
-      extend T::Sig
+      class RangeIterator
+        def initialize(elements)
+          @head = 0
+          @tail = elements.length.pred
+          @elements = elements
+        end
 
-      class Events < T::Enum
-        enums do
-          Patch = new
-          Init = new
-          Move = new
-          Insert = new
-          Remove = new
+        def done? = @head > @tail
+
+        def head = @elements[@head]
+        def tail = @elements[@tail]
+
+        def tail_idx = @tail
+
+        def next_head! = @head += 1
+        def next_tail! = @tail -= 1
+
+        def to_a = @elements[to_range] || []
+        def to_range = @head..@tail
+
+        def [](idx)
+          @elements[idx]
+        end
+
+        def []=(idx, value)
+          @elements[idx] = value
         end
       end
 
-      Event =
-        T.type_alias do
-          T.any(
-            [Events::Patch, vnode: VNode, descriptor: Interfaces::Descriptor],
-            [Events::Init, descriptor: Interfaces::Descriptor],
-            [Events::Move, vnode: VNode, before: T.nilable(VNode)],
-            [Events::Insert, vnode: VNode, before: T.nilable(VNode)],
-            [Events::Remove, vnode: VNode]
-          )
+      module Patches
+        extend T::Sig
+
+        class Init < T::Struct
+          const :descriptor, Interfaces::Descriptor
+          def inspect = "#{self.class.name}(#{descriptor.type.to_s})"
         end
+
+        class InsertBefore < T::Struct
+          const :vnode, VNode
+          const :ref, T.nilable(VNode)
+
+          def inspect =
+            "#{self.class.name}(#{vnode.id.inspect}, #{ref&.id.inspect})"
+        end
+
+        class InsertAfter < T::Struct
+          const :vnode, VNode
+          const :ref, T.nilable(VNode)
+
+          def inspect =
+            "#{self.class.name}(#{vnode.id.inspect}, #{ref&.id.inspect})"
+        end
+
+        class Patch < T::Struct
+          const :vnode, VNode
+          const :descriptor, Interfaces::Descriptor
+          def inspect =
+            "#{self.class.name}(#{vnode.id.inspect}, #{descriptor.type.to_s})"
+        end
+
+        class Remove < T::Struct
+          const :vnode, VNode
+          def inspect = "#{self.class.name}(#{vnode.id.inspect})"
+        end
+
+        Any =
+          T.type_alias { T.any(Init, InsertBefore, InsertAfter, Patch, Remove) }
+      end
+
+      extend T::Sig
 
       sig do
         params(
-          vnodes: T::Array[VNode],
+          old_children: T::Array[VNode],
           descriptors: T::Array[Interfaces::Descriptor],
-          block: T.proc.params(arg0: Event).returns(T.nilable(VNode))
+          block: T.proc.params(arg0: Patches::Any).returns(T.nilable(VNode))
         ).returns(T::Array[VNode])
       end
-      def self.reconcile(vnodes, descriptors, &block)
+      def self.reconcile(old_children, descriptors, &block)
         # TODO: Make it possible to disable the following check in production:
         Children.check_duplicate_keys(descriptors)
 
-        new_children = T.let([], T::Array[VNode])
-
-        vnodes = vnodes.compact
-        descriptors = descriptors.compact
-        old_ids = vnodes.map(&:id)
-
-        indexes = Indexes.new(vnodes.map(&:id))
+        grouped = old_children.group_by { _1.descriptor }
 
         new_children =
-          descriptors.map.with_index do |descriptor, i|
-            vnode = vnodes.find { _1.same?(descriptor) }
+          descriptors
+            .map do |descriptor|
+              if vnode = grouped[descriptor]&.shift
+                yield Patches::Patch.new(vnode:, descriptor:)
+              else
+                yield Patches::Init.new(descriptor:)
+              end
+            end
+            .compact
 
-            if vnode
-              vnodes.delete(vnode)
-              yield [Events::Patch, vnode:, descriptor:]
-            else
-              yield [Events::Init, descriptor:]
+        delta_time_ms =
+          Mayu::Utils.measure_time do
+            diff(old_children, new_children).each { |patch| yield patch }
+
+            grouped.values.flatten.each do |removed|
+              yield Patches::Remove.new(vnode: removed)
             end
           end
-
-        # This is very inefficient.
-        # I tried to get the algorithm from snabbdom/vue to work,
-        # but it's not very easy to get right.
-        # I always got some weird ordering issues and it's tricky to debug.
-        # Fun stuff for later though.
-
-        start_at = Time.now
-        all_vnodes = vnodes + new_children
-
-        new_children.each_with_index do |vnode, expected_index|
-          new_indexes = Indexes.new(indexes.to_a - vnodes.map(&:id))
-          current_index = indexes.index(vnode.id)
-
-          before_id = indexes[expected_index]
-          before = before_id && all_vnodes.find { _1.id == before_id } || nil
-
-          if old_ids.include?(vnode.id)
-            unless current_index == expected_index
-              yield [Events::Move, vnode:, before:]
-              indexes.insert_before(vnode.id, before_id)
-            end
-          else
-            yield [Events::Insert, vnode:, before:]
-            indexes.insert_before(vnode.id, before_id)
-          end
-        end
-
-        vnodes.each { |vnode| yield [Events::Remove, vnode:] }
-
-        delta_time_ms = (Time.now - start_at) * 1000
 
         if delta_time_ms > 10
           Console.logger.warn(self, "Updating took %.3fms" % delta_time_ms)
         end
 
         new_children
+      end
+
+      def self.diff(old, new)
+        old = old.dup
+        new = new.dup
+
+        old_ids = old.map(&:id).sort
+
+        iold = RangeIterator.new(old)
+        inew = RangeIterator.new(new)
+
+        ops = []
+
+        until iold.done? || inew.done?
+          iold.next_head! and next unless iold.head
+          iold.next_tail! and next unless iold.tail
+          inew.next_head! and next unless inew.head
+          inew.next_tail! and next unless inew.tail
+
+          if iold.tail.eql?(inew.tail)
+            iold.next_tail!
+            inew.next_tail!
+            next
+          end
+
+          if iold.head.eql?(inew.head)
+            iold.next_head!
+            inew.next_head!
+            next
+          end
+
+          if iold.head.eql?(inew.tail)
+            # Right move
+            ops << Patches::InsertAfter.new(vnode: iold.head, ref: iold.tail)
+            iold.next_head!
+            inew.next_tail!
+            next
+          end
+
+          if iold.tail.eql?(inew.head)
+            # Left move
+            ops << Patches::InsertBefore.new(vnode: iold.tail, ref: iold.head)
+            inew.next_head!
+            iold.next_tail!
+            next
+          end
+
+          if old_index = old.find_index { _1.eql?(inew.head) }
+            old[old_index] = nil
+            ops << Patches::InsertBefore.new(vnode: inew.head, ref: iold.head)
+            inew.next_head!
+            next
+          end
+
+          ops << Patches::InsertBefore.new(vnode: inew.head, ref: iold.head)
+
+          inew.next_head!
+        end
+
+        if iold.done?
+          before = new[inew.tail_idx.succ]
+
+          until inew.done?
+            ops << Patches::InsertBefore.new(vnode: inew.head, ref: before)
+            inew.next_head!
+          end
+        elsif inew.done?
+          iold.to_a.compact.each do |vnode|
+            # ops << Patches::Remove.new(vnode:)
+          end
+        end
+
+        ops
       end
     end
   end

--- a/lib/mayu/vdom/reconciliation.test.rb
+++ b/lib/mayu/vdom/reconciliation.test.rb
@@ -1,0 +1,56 @@
+# typed: true
+
+require "minitest/autorun"
+require "test_helper"
+require_relative "../utils"
+require_relative "reconciliation"
+require_relative "descriptor"
+require_relative "h"
+
+class Mayu::VDOM::Reconciliation::Test < Minitest::Test
+  class VNode < T::Struct
+    extend T::Sig
+    include Mayu::VDOM::Interfaces::VNode
+
+    const :id, String, factory: -> { SecureRandom.alphanumeric(8) }
+    prop :descriptor, Mayu::VDOM::Descriptor
+  end
+
+  def test_reconciliation
+    descriptors = 200.times.map { |i| Mayu::VDOM::H[:li, i.to_s, key: i] }
+
+    patches = []
+
+    vnodes = T.let([], T::Array[VNode])
+
+    p Mayu::Utils.measure_time { vnodes = update(vnodes, descriptors) }
+
+    assert_equal(vnodes.map(&:descriptor), descriptors)
+
+    descriptors = descriptors.shuffle
+
+    p Mayu::Utils.measure_time { vnodes = update(vnodes, descriptors) }
+
+    descriptors = descriptors.shuffle.slice(0..100).to_a
+
+    p Mayu::Utils.measure_time { vnodes = update(vnodes, descriptors) }
+
+    assert_equal(vnodes.map(&:descriptor).map(&:key), descriptors.map(&:key))
+  end
+
+  def update(vnodes, descriptors)
+    Mayu::VDOM::Reconciliation
+      .reconcile(vnodes, descriptors) do
+        case _1
+        in Mayu::VDOM::Reconciliation::Patches::Init => init
+          VNode.new(descriptor: init.descriptor)
+        in Mayu::VDOM::Reconciliation::Patches::Patch => patch
+          vnode = patch.vnode
+          vnode.descriptor = patch.descriptor
+          vnode
+        end
+      end
+      .vnodes
+      .then { T.cast(_1, T::Array[VNode]) }
+  end
+end

--- a/lib/mayu/vdom/reconciliation.test.rb
+++ b/lib/mayu/vdom/reconciliation.test.rb
@@ -39,8 +39,8 @@ class Mayu::VDOM::Reconciliation::Test < Minitest::Test
   end
 
   def update(vnodes, descriptors)
-    Mayu::VDOM::Reconciliation
-      .reconcile(vnodes, descriptors) do
+    result =
+      Mayu::VDOM::Reconciliation.reconcile(vnodes, descriptors) do
         case _1
         in Mayu::VDOM::Reconciliation::Patches::Init => init
           VNode.new(descriptor: init.descriptor)
@@ -50,7 +50,7 @@ class Mayu::VDOM::Reconciliation::Test < Minitest::Test
           vnode
         end
       end
-      .vnodes
-      .then { T.cast(_1, T::Array[VNode]) }
+    p(count: result.patches.length)
+    result.vnodes.then { T.cast(_1, T::Array[VNode]) }
   end
 end

--- a/lib/mayu/vdom/update_context.rb
+++ b/lib/mayu/vdom/update_context.rb
@@ -56,14 +56,6 @@ module Mayu
         ).void
       end
       def insert(vnode, before: nil, after: nil)
-        # if before
-        #   puts "\e[32minsert\e[0m #{vnode.dom_id} before #{before.dom_id}"
-        # elsif after
-        #   puts "\e[32minsert\e[0m #{vnode.dom_id} after #{after.dom_id}"
-        # else
-        #   puts "\e[32minsert\e[0m #{vnode.dom_id} last"
-        # end
-        # p caller.grep(/markup/).first(5)
         html = vnode.to_html
         ids = vnode.id_tree
 
@@ -96,13 +88,6 @@ module Mayu
         end
       end
 
-      # sig {params(args: T.untyped).void}
-      # def puts(*args)
-      #   if @parents.last&.descriptor&.type == :ul
-      #     T.unsafe(Kernel)::puts(*args)
-      #   end
-      # end
-
       sig do
         params(
           vnode: VNode,
@@ -111,17 +96,6 @@ module Mayu
         ).void
       end
       def move(vnode, before: nil, after: nil)
-        #   if before
-        # #    raise if vnode.key == 3 && before.key == 7
-        #     puts "\e[33mmove:\e[0m #{vnode.dom_id} before #{before.key}"
-        #   elsif after
-        #     puts "\e[33mmove:\e[0m #{vnode.dom_id} after #{after.key}"
-        #   else
-        #     puts "\e[33mmove:\e[0m #{vnode.dom_id} last"
-        #   end
-
-        #  p dom_parent_id: vnode.dom_parent_id, vnode_id: vnode.id, vnode_dom_id: vnode.dom_id, type: vnode.descriptor.type.to_s
-
         if before
           add_patch(
             :move,

--- a/lib/mayu/vdom/update_context.rb
+++ b/lib/mayu/vdom/update_context.rb
@@ -35,7 +35,7 @@ module Mayu
       def enter(vnode, &blk)
         # Sleep so that the fiber yields,
         # so that other things can run..
-        sleep(0)
+        # sleep(0)
 
         dom_parent_id =
           (vnode.descriptor.element? ? vnode.id : vnode.dom_parent_id)

--- a/lib/mayu/vdom/update_context.rb
+++ b/lib/mayu/vdom/update_context.rb
@@ -35,7 +35,7 @@ module Mayu
       def enter(vnode, &blk)
         # Sleep so that the fiber yields,
         # so that other things can run..
-        # sleep(0)
+        sleep(0)
 
         dom_parent_id =
           (vnode.descriptor.element? ? vnode.id : vnode.dom_parent_id)

--- a/lib/mayu/vdom/vnode.rb
+++ b/lib/mayu/vdom/vnode.rb
@@ -136,6 +136,11 @@ module Mayu
         self.descriptor.eql?(descriptor)
       end
 
+      sig { params(other: T.untyped).returns(T::Boolean) }
+      def eql?(other)
+        self.class === other && other.id == id
+      end
+
       sig { returns(T.untyped) }
       def id_tree
         children = Array(self.children).flatten.compact

--- a/lib/mayu/vdom/vnode.rb
+++ b/lib/mayu/vdom/vnode.rb
@@ -12,6 +12,7 @@ module Mayu
   module VDOM
     class VNode < T::Struct
       extend T::Sig
+      include Interfaces::VNode
 
       Children = T.type_alias { T::Array[VNode] }
       Id = T.type_alias { IdGenerator::Type }

--- a/lib/mayu/vdom/vtree.rb
+++ b/lib/mayu/vdom/vtree.rb
@@ -20,7 +20,6 @@ module Mayu
   module VDOM
     class VTree
       extend T::Sig
-
       include Interfaces::VTree
 
       class Updater
@@ -259,7 +258,7 @@ module Mayu
         @root&.id_tree
       end
 
-      sig { params(vnode: VNode).void }
+      sig { override.params(vnode: VNode).void }
       def enqueue_update!(vnode)
         component = vnode.component
         return unless component
@@ -542,26 +541,34 @@ module Mayu
         ).returns(T::Array[VNode])
       end
       def update_children(ctx, vnodes, descriptors, lifecycles:)
-        Reconciliation.reconcile(vnodes, descriptors) do |event|
-          old_ids = vnodes.map(&:id).sort
+        initialized = T.let([], T::Array[VNode::Id])
 
-          case event
-          in Reconciliation::Patches::Init => init
-            init_vnode(ctx, init.descriptor, lifecycles:)
-          in Reconciliation::Patches::Patch => patch
-            patch_vnode(ctx, patch.vnode, patch.descriptor, lifecycles:)
+        result =
+          Reconciliation.reconcile(vnodes, descriptors) do
+            case _1
+            in Reconciliation::Patches::Init => init
+              vnode = init_vnode(ctx, init.descriptor, lifecycles:)
+              initialized.push(vnode.id)
+              vnode
+            in Reconciliation::Patches::Patch => patch
+              patch_vnode(ctx, patch.vnode, patch.descriptor, lifecycles:)
+            end
+          end
+
+        result.patches.each do |patch|
+          case patch
           in Reconciliation::Patches::InsertBefore => insert
-            if old_ids.include?(insert.vnode.id)
-              ctx.move(insert.vnode, before: insert.ref)
-            else
+            if initialized.delete(insert.vnode.id)
               ctx.insert(insert.vnode, before: insert.ref)
+            else
+              ctx.move(insert.vnode, before: insert.ref)
             end
             nil
           in Reconciliation::Patches::InsertAfter => insert
-            if old_ids.include?(insert.vnode.id)
-              ctx.move(insert.vnode, after: insert.ref)
-            else
+            if initialized.delete(insert.vnode.id)
               ctx.insert(insert.vnode, after: insert.ref)
+            else
+              ctx.move(insert.vnode, after: insert.ref)
             end
             nil
           in Reconciliation::Patches::Remove => remove
@@ -569,6 +576,8 @@ module Mayu
             nil
           end
         end
+
+        T.cast(result.vnodes, T::Array[VNode])
       end
 
       sig do

--- a/sorbet/rbi/shims/fiber.rb
+++ b/sorbet/rbi/shims/fiber.rb
@@ -1,0 +1,15 @@
+# typed: strict
+
+class Fiber
+  class << self
+    extend T::Sig
+
+    sig {params(key: T.any(String, Symbol)).returns(T.untyped)}
+    def [](key)
+    end
+
+    sig {params(key: T.any(String, Symbol), value: T.untyped).void}
+    def []=(key, value)
+    end
+  end
+end


### PR DESCRIPTION
Add the famous two way diff used in many other VDOM implementations.

basic benchmarks with random orders:

## old implementation (ms)
500 inserts: 14.782000064849854
500 shuffle: 71.27499997615814
shuffle and remove 300: 19.103000044822693

## new implementation (ms)
500 inserts: 7.65500009059906
500 shuffle: 18.229999899864197
shuffle and remove 300: 4.972000002861023