### PR TITLE
Update example app to v0.0.6

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,6 +1,6 @@
-FROM ruby:3.2.2-alpine3.17 as base
+FROM ruby:3.3.0-alpine3.18 as base
 
-ARG BUNDLER_VERSION=2.4.6
+ARG BUNDLER_VERSION=2.5.3
 ARG BUNDLE_WITHOUT=development:test
 ARG BUNDLE_PATH=vendor/bundle
 ENV BUNDLE_PATH ${BUNDLE_PATH}
@@ -9,6 +9,7 @@ RUN gem install -N bundler -v ${BUNDLER_VERSION}
 RUN apk update && apk add --no-cache \
   curl bash jemalloc gcompat libsodium \
   imagemagick imlib2
+# RUN ln -s /usr/lib/libsodium.so.26 /usr/lib/libsodium.so.23
 SHELL ["/bin/bash", "-c"]
 WORKDIR /app
 
@@ -25,6 +26,6 @@ FROM base AS final
 COPY .fly /fly
 COPY --from=install /app /app
 ENV PORT 3000
-ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
+# ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
 ENTRYPOINT ["/fly/entrypoint.sh"]
 CMD ["bin/mayu", "serve", "--disable-sorbet"]

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -7,16 +7,14 @@ ENV BUNDLE_PATH ${BUNDLE_PATH}
 ENV BUNDLE_WITHOUT ${BUNDLE_WITHOUT}
 RUN gem install -N bundler -v ${BUNDLER_VERSION}
 RUN apk update && apk add --no-cache \
-  curl bash jemalloc gcompat libsodium \
-  imagemagick imlib2
-# RUN ln -s /usr/lib/libsodium.so.26 /usr/lib/libsodium.so.23
+  curl bash jemalloc gcompat libsodium
 SHELL ["/bin/bash", "-c"]
 WORKDIR /app
 
 FROM base AS install
 RUN apk update && apk add --no-cache \
   build-base gzip brotli \
-  pkgconfig imagemagick imagemagick-dev imlib2 imlib2-dev
+  pkgconfig imagemagick-dev
 COPY Gemfile* .
 RUN bundle install
 COPY . .
@@ -26,6 +24,6 @@ FROM base AS final
 COPY .fly /fly
 COPY --from=install /app /app
 ENV PORT 3000
-# ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
+ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
 ENTRYPOINT ["/fly/entrypoint.sh"]
 CMD ["bin/mayu", "serve", "--disable-sorbet"]

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -1,25 +1,27 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    async (2.3.1)
+    async (2.8.0)
       console (~> 1.10)
+      fiber-annotation
       io-event (~> 1.1)
       timers (~> 4.1)
     async-container (0.16.12)
       async
       async-io
-    async-http (0.59.5)
+    async-http (0.61.0)
       async (>= 1.25)
       async-io (>= 1.28)
       async-pool (>= 0.2)
-      protocol-http (~> 0.23)
-      protocol-http1 (~> 0.14.0)
-      protocol-http2 (~> 0.14.0)
-      traces (>= 0.8.0)
-    async-io (1.38.0)
+      protocol-http (~> 0.25.0)
+      protocol-http1 (~> 0.16.0)
+      protocol-http2 (~> 0.15.0)
+      traces (>= 0.10.0)
+    async-io (1.38.1)
       async
     async-pool (0.4.0)
       async (>= 1.25)
+    base64 (0.2.0)
     brotli (0.4.0)
     citrus (3.0.2)
     coderay (1.1.3)
@@ -35,7 +37,7 @@ GEM
       thor
       tilt
     image_size (3.2.0)
-    io-event (1.3.3)
+    io-event (1.4.1)
     json (2.7.1)
     kramdown (2.4.0)
       rexml
@@ -43,23 +45,24 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     localhost (1.1.10)
-    mayu-css (0.0.3-arm64-darwin)
-    mayu-css (0.0.3-x86_64-darwin)
-    mayu-live (0.0.5)
-      async (~> 2.3.0)
+    mayu-css (0.1.2-arm64-darwin)
+    mayu-css (0.1.2-x86_64-darwin)
+    mayu-live (0.0.6)
+      async (~> 2.8.0)
       async-container (~> 0.16.12)
-      async-http (~> 0.59.4)
+      async-http (~> 0.61.0)
+      base64 (~> 0.2.0)
       brotli (~> 0.4.0)
       image_size (~> 3.2.0)
       kramdown (~> 2.4.0)
       listen (~> 3.7.1)
       localhost (~> 1.1.9)
-      mayu-css (~> 0.0.3)
+      mayu-css (~> 0.1.2)
       mime-types (~> 3.4.1)
       msgpack (~> 1.6.0)
       nanoid (~> 2.0.0)
       prometheus-client (~> 4.0.0)
-      protocol-http (~> 0.23.12)
+      protocol-http (~> 0.25.0)
       pry (~> 0.14.2)
       rack (>= 3.0.4.1, < 3.0.9.0)
       rake (~> 13.0.6)
@@ -83,10 +86,10 @@ GEM
     prettier_print (1.2.1)
     prometheus-client (4.0.0)
     protocol-hpack (1.4.2)
-    protocol-http (0.23.12)
-    protocol-http1 (0.14.6)
+    protocol-http (0.25.0)
+    protocol-http1 (0.16.1)
       protocol-http (~> 0.22)
-    protocol-http2 (0.14.2)
+    protocol-http2 (0.15.1)
       protocol-hpack (~> 1.4)
       protocol-http (~> 0.18)
     pry (0.14.2)
@@ -103,7 +106,7 @@ GEM
     rmagick (5.3.0)
       pkg-config (~> 1.4)
     rouge (4.0.1)
-    sorbet-runtime (0.5.11150)
+    sorbet-runtime (0.5.11181)
     source_map (3.0.1)
       json
     syntax_tree (5.3.0)
@@ -128,6 +131,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-20
 
 DEPENDENCIES
@@ -135,4 +139,4 @@ DEPENDENCIES
   mayu-live
 
 BUNDLED WITH
-   2.4.6
+   2.5.3

--- a/example/app/components/Layout/Footer.haml
+++ b/example/app/components/Layout/Footer.haml
@@ -1,4 +1,5 @@
 :ruby
+  require "mayu/version"
   Badge = import("./Footer/Badge")
 
   BADGES = [
@@ -35,6 +36,14 @@
     %a(href="https://github.com/mayu-live" target="_blank")<
       github.com/mayu-live
 
+  %dl.versions
+    %dt Mayu
+    %dd #{::Mayu::VERSION}
+    %dt Ruby
+    %dd #{::RUBY_VERSION}
+    %dt YJIT
+    %dd #{RubyVM::YJIT.enabled? ? "enabled" : "disabled"}
+
   %p.badges
     = BADGES.map do |badge|
       %Badge{**badge}[badge[:src]]
@@ -65,4 +74,21 @@
     text-decoration: underline;
     color: #fff;
     opacity: 1;
+  }
+
+  .versions {
+    & :is(dt, dd) {
+      display: inline-block;
+      margin: 0;
+      padding: 0;
+    }
+
+    & dt {
+      font-weight: bold;
+      margin-right: .5ch;
+    }
+
+    & dd {
+      margin-right: 1em;
+    }
   }

--- a/example/fly.toml
+++ b/example/fly.toml
@@ -1,54 +1,54 @@
+# fly.toml app configuration file generated for mayu on 2024-01-11T00:11:41-05:00
+#
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
 
 app = "mayu"
 primary_region = "bog"
-
 kill_signal = "SIGINT"
-kill_timeout = 5
-processes = []
+kill_timeout = "5s"
 
-[env]
-  ENABLE_YJIT=false
+[build]
 
 [deploy]
   strategy = "rolling"
 
-[metrics]
-  port = 9092
-  path = "/metrics"
+[env]
+  ENABLE_YJIT = "false"
 
 [[services]]
+  protocol = "tcp"
   internal_port = 3000
-  force_https = true
   auto_stop_machines = true
   auto_start_machines = true
   min_machines_running = 1
 
-  [services.concurrency]
-    hard_limit = 25
-    soft_limit = 20
-    type = "connections"
-
   [[services.ports]]
     port = 80
-    force_https = true
     handlers = ["http"]
+    force_https = true
 
   [[services.ports]]
     port = 443
     handlers = ["tls"]
-    tls_options = { "alpn" = ["h2"] }
+    [services.ports.tls_options]
+      alpn = ["h2"]
+
+  [services.concurrency]
+    type = "connections"
+    hard_limit = 25
+    soft_limit = 20
 
   [[services.tcp_checks]]
-    grace_period = "1s"
     interval = "15s"
-    restart_limit = 0
     timeout = "2s"
+    grace_period = "1s"
 
-  # [[services.http_checks]]
-  #   type = "http"
-  #   interval = 10000
-  #   restart_limit = 0
-  #   timeout = 2000
-  #   method = "get"
-  #   path = "/__mayu/status"
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory_mb = 512
+
+[[metrics]]
+  port = 9092
+  path = "/metrics"

--- a/example/fly.toml
+++ b/example/fly.toml
@@ -14,7 +14,7 @@ kill_timeout = "5s"
   strategy = "rolling"
 
 [env]
-  ENABLE_YJIT = "false"
+  ENABLE_YJIT = "true"
 
 [[services]]
   protocol = "tcp"

--- a/exe/mayu
+++ b/exe/mayu
@@ -23,6 +23,7 @@ else
   puts "\e[2mYJIT is not supported!\e[0m"
 end
 
+require "mayu/version"
 require "mayu/banner"
 require "mayu/commands"
 


### PR DESCRIPTION
This doesn't work. I'm getting segfaults when starting the app on fly.io, and I have no clue why. Same issue with Alpine 3.19 and ubuntu-bullseye. Works on my Mac M2.

```
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info] INFO Starting init (commit: 8995e367)...
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info] INFO Preparing to run: `/fly/entrypoint.sh bin/mayu serve --disable-sorbet` as root
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info] INFO [fly api proxy] listening at /.fly/api
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]2024/01/10 17:47:42 listening on [fdaa:0:5b8f:a7b:cf:97d4:923f:2]:22 (DNS: [fdaa::3]:53)
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]YJIT is not enabled. Enable by setting ENABLE_YJIT=true in fly.toml
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]/usr/local/lib/ruby/3.3.0/rubygems.rb:165: [BUG] Segmentation fault at 0xffffffffffffffff
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-linux]
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]-- Control frame information -----------------------------------------------
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]c:0005 p:0074 s:0023 e:000021 CLASS  /usr/local/lib/ruby/3.3.0/rubygems.rb:165
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]c:0004 p:0045 s:0019 e:000018 TOP    /usr/local/lib/ruby/3.3.0/rubygems.rb:115 [FINISH]
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]c:0003 p:---- s:0012 e:000011 CFUNC  :require
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]c:0002 p:0012 s:0007 e:000006 TOP    <internal:gem_prelude>:2 [FINISH]
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]c:0001 p:0000 s:0003 E:001090 DUMMY  [FINISH]
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]-- Ruby level backtrace information ----------------------------------------
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]<internal:gem_prelude>:2:in `<internal:gem_prelude>'
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]<internal:gem_prelude>:2:in `require'
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]/usr/local/lib/ruby/3.3.0/rubygems.rb:115:in `<top (required)>'
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]/usr/local/lib/ruby/3.3.0/rubygems.rb:165:in `<module:Gem>'
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]-- Threading information ---------------------------------------------------
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]Total ractor count: 1
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]Ruby thread count for this ractor: 1
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]-- Machine register context ------------------------------------------------
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info] RIP: 0x00007f2559d0fcb8 RBP: 0x00007f255808f050 RSP: 0x00007ffdbe09cb88
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info] RAX: 0xffffffffffffffff RBX: 0x00007f255808f3e8 RCX: 0x00005573b05fe670
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info] RDX: 0x00007f255808f3e9 RDI: 0x0000000000000001 RSI: 0x000000000000c2e3
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]  R8: 0x00000000ffffffff  R9: 0x00005573b080d660 R10: 0x000000000000c293
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info] R11: 0xffffffffffffffff R12: 0x00007f255808f578 R13: 0x00007f255a0a0920
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info] R14: 0x00007f2558047f98 R15: 0x0000000000000001 EFL: 0x0000000000010202
2024-01-10T17:47:42Z app[148edd30c25d89] bog [info]-- C level backtrace information -------------------------------------------
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(rb_print_backtrace+0x11) [0x7f2559dc35c7] vm_dump.c:820
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(rb_vm_bugreport) vm_dump.c:1151
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(rb_bug_for_fatal_signal+0x100) [0x7f2559bc2b00] error.c:1065
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(sigsegv+0x49) [0x7f2559d12049] signal.c:926
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/lib/x86_64-linux-gnu/libpthread.so.0(__restore_rt+0x0) [0x7f2559867140]
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(redblack_new+0x13) [0x7f2559d0fcb8] shape.c:148
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(redblack_insert_aux) shape.c:247
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(redblack_color+0x0) [0x7f2559d0fe4f] shape.c:287
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(redblack_red_p) shape.c:111
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(redblack_insert) shape.c:289
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(redblack_cache_ancestors) shape.c:434
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(redblack_cache_ancestors+0x15) [0x7f2559d0fe2d] shape.c:431
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(redblack_cache_ancestors) shape.c:431
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(redblack_cache_ancestors+0x15) [0x7f2559d0fe2d] shape.c:431
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(redblack_cache_ancestors) shape.c:431
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(redblack_cache_ancestors+0x15) [0x7f2559d0fe2d] shape.c:431
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(redblack_cache_ancestors) shape.c:431
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(redblack_cache_ancestors+0x15) [0x7f2559d0fe2d] shape.c:431
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(redblack_cache_ancestors) shape.c:431
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(redblack_cache_ancestors+0x15) [0x7f2559d0fe2d] shape.c:431
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(redblack_cache_ancestors) shape.c:431
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(rb_shape_alloc_new_child+0x8) [0x7f2559d10db8] shape.c:473
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(get_next_shape_internal) shape.c:529
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(rb_shape_get_next) shape.c:721
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(general_ivar_set+0x4b) [0x7f2559d8b7cf] variable.c:1513
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(rb_class_ivar_set) variable.c:4236
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(rb_ivar_set+0x84) [0x7f2559d8b9a4] variable.c:1844
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(vm_exec_core+0x261b) [0x7f2559da8d1b] vm_insnhelper.c:1639
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(rb_vm_exec+0x18a) [0x7f2559dac70a] vm.c:2486
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(load_iseq_eval+0x9) [0x7f2559c3380d] load.c:774
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(require_internal) load.c:1281
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(rb_require_string_internal+0x34) [0x7f2559c344f7] load.c:1380
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(rb_require_string) load.c:1373
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(vm_cfp_consistent_p+0x0) [0x7f2559d95d4d] vm_insnhelper.c:3490
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(vm_call_cfunc_with_frame_) vm_insnhelper.c:3492
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(vm_call_cfunc_with_frame) vm_insnhelper.c:3518
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(vm_call_cfunc_other) vm_insnhelper.c:3544
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(vm_sendish+0x51) [0x7f2559da680b] vm_insnhelper.c:5581
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(vm_exec_core) insns.def:834
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(rb_vm_exec+0x18a) [0x7f2559dac70a] vm.c:2486
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(rb_intern_const+0x0) [0x7f2559d0c07f] ruby.c:1730
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(ruby_init_prelude) ruby.c:1731
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(ruby_opt_init) ruby.c:1791
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(ruby_opt_init+0x16) [0x7f2559d0c698] ruby.c:1749
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(load_file_internal) ruby.c:2599
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(rb_ensure+0x113) [0x7f2559bcc3b3] eval.c:1009
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(load_file+0x49) [0x7f2559d0e171] ruby.c:2760
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(process_options) ruby.c:2296
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(ruby_process_options+0x142) [0x7f2559d0e882] ruby.c:3014
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/lib/libruby.so.3.3(ruby_options+0xcd) [0x7f2559bcd48d] eval.c:121
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/bin/ruby(rb_main+0x19) [0x5573ae6e810b] ./main.c:39
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/usr/local/bin/ruby(main) ./main.c:58
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xea) [0x7f25596a3d0a]
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info][0x5573ae6e815a]
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]-- Other runtime information -----------------------------------------------
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]* Loaded script: ruby
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]* Loaded features:
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]    0 enumerator.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]    1 thread.rb
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]    2 fiber.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]    3 rational.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]    4 complex.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]    5 ruby2_keywords.rb
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]    6 /usr/local/lib/ruby/3.3.0/x86_64-linux/enc/encdb.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]    7 /usr/local/lib/ruby/3.3.0/x86_64-linux/enc/trans/transdb.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]    8 /usr/local/lib/ruby/3.3.0/x86_64-linux/rbconfig.rb
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]    9 /usr/local/lib/ruby/3.3.0/rubygems/compatibility.rb
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]   10 /usr/local/lib/ruby/3.3.0/rubygems/defaults.rb
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]   11 /usr/local/lib/ruby/3.3.0/rubygems/deprecate.rb
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]   12 /usr/local/lib/ruby/3.3.0/rubygems/errors.rb
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]* Process memory map:
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]5573ae6e7000-5573ae6e8000 r--p 00000000 fe:00 399004                     /usr/local/bin/ruby
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]5573ae6e8000-5573ae6e9000 r-xp 00001000 fe:00 399004                     /usr/local/bin/ruby
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]5573ae6e9000-5573ae6ea000 r--p 00002000 fe:00 399004                     /usr/local/bin/ruby
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]5573ae6ea000-5573ae6eb000 r--p 00002000 fe:00 399004                     /usr/local/bin/ruby
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]5573ae6eb000-5573ae6ec000 rw-p 00003000 fe:00 399004                     /usr/local/bin/ruby
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]5573b05fe000-5573b092f000 rw-p 00000000 00:00 0                          [heap]
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2553398000-7f2553569000 r--s 00000000 fe:00 109                        /lib/x86_64-linux-gnu/libc-2.31.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2553569000-7f2554eca000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2554eca000-7f2556140000 r--s 00000000 fe:00 399217                     /usr/local/lib/libruby.so.3.3.0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556140000-7f2556150000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556260000-7f2556270000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556300000-7f2556310000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556327000-7f255634c000 r--s 00000000 fe:00 154                        /lib/x86_64-linux-gnu/libpthread-2.31.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255634c000-7f2556380000 r--s 00000000 fe:00 399004                     /usr/local/bin/ruby
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556380000-7f25563e0000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25563ef000-7f25563f0000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25563f0000-7f2556491000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556491000-7f2556492000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556492000-7f2556533000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556533000-7f2556534000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556534000-7f25565d5000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25565d5000-7f25565d6000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25565d6000-7f2556677000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556677000-7f2556678000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556678000-7f2556719000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556719000-7f255671a000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255671a000-7f25567bb000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25567bb000-7f25567bc000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25567bc000-7f255685d000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255685d000-7f255685e000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255685e000-7f25568ff000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25568ff000-7f2556900000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556900000-7f25569a1000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25569a1000-7f25569a2000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25569a2000-7f2556a43000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556a43000-7f2556a44000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556a44000-7f2556ae5000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556ae5000-7f2556ae6000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556ae6000-7f2556b87000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556b87000-7f2556b88000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556b88000-7f2556c29000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556c29000-7f2556c2a000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556c2a000-7f2556ccb000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556ccb000-7f2556ccc000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556ccc000-7f2556d6d000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556d6d000-7f2556d6e000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556d6e000-7f2556e0f000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556e0f000-7f2556e10000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556e10000-7f2556eb1000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556eb1000-7f2556eb2000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556eb2000-7f2556f53000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556f53000-7f2556f54000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556f54000-7f2556ff5000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556ff5000-7f2556ff6000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2556ff6000-7f2557097000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2557097000-7f2557098000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2557098000-7f2557139000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2557139000-7f255713a000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255713a000-7f25571db000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25571db000-7f25571dc000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25571dc000-7f255727d000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255727d000-7f255727e000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255727e000-7f255731f000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255731f000-7f2557320000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2557320000-7f25573c1000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25573c1000-7f25573c2000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25573c2000-7f2557463000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2557463000-7f2557464000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2557464000-7f2557505000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2557505000-7f2557506000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2557506000-7f25575a7000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25575a7000-7f25575a8000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25575a8000-7f2557649000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2557649000-7f255764a000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255764a000-7f25576eb000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25576eb000-7f25576ec000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25576ec000-7f255778d000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255778d000-7f255778e000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255778e000-7f255782f000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255782f000-7f2557830000 ---p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2557830000-7f2558080000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2558089000-7f255808a000 r--p 00000000 fe:00 1031                       /usr/local/lib/ruby/3.3.0/x86_64-linux/enc/trans/transdb.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255808a000-7f255808c000 r-xp 00001000 fe:00 1031                       /usr/local/lib/ruby/3.3.0/x86_64-linux/enc/trans/transdb.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255808c000-7f255808d000 r--p 00003000 fe:00 1031                       /usr/local/lib/ruby/3.3.0/x86_64-linux/enc/trans/transdb.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255808d000-7f255808e000 r--p 00003000 fe:00 1031                       /usr/local/lib/ruby/3.3.0/x86_64-linux/enc/trans/transdb.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255808e000-7f255808f000 rw-p 00004000 fe:00 1031                       /usr/local/lib/ruby/3.3.0/x86_64-linux/enc/trans/transdb.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255808f000-7f2559500000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2559500000-7f2559501000 r--p 00000000 fe:00 987                        /usr/local/lib/ruby/3.3.0/x86_64-linux/enc/encdb.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2559501000-7f2559502000 r-xp 00001000 fe:00 987                        /usr/local/lib/ruby/3.3.0/x86_64-linux/enc/encdb.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2559502000-7f2559503000 r--p 00002000 fe:00 987                        /usr/local/lib/ruby/3.3.0/x86_64-linux/enc/encdb.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2559503000-7f2559504000 r--p 00002000 fe:00 987                        /usr/local/lib/ruby/3.3.0/x86_64-linux/enc/encdb.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2559504000-7f2559505000 rw-p 00003000 fe:00 987                        /usr/local/lib/ruby/3.3.0/x86_64-linux/enc/encdb.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2559505000-7f2559606000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2559606000-7f255960d000 r--s 00000000 fe:00 393811                     /usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255960d000-7f2559662000 r--p 00000000 fe:00 393531                     /usr/lib/locale/C.UTF-8/LC_CTYPE
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2559662000-7f2559666000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2559666000-7f2559669000 r--p 00000000 fe:00 123                        /lib/x86_64-linux-gnu/libgcc_s.so.1
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2559669000-7f255967a000 r-xp 00003000 fe:00 123                        /lib/x86_64-linux-gnu/libgcc_s.so.1
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255967a000-7f255967e000 r--p 00014000 fe:00 123                        /lib/x86_64-linux-gnu/libgcc_s.so.1
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255967e000-7f255967f000 r--p 00017000 fe:00 123                        /lib/x86_64-linux-gnu/libgcc_s.so.1
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255967f000-7f2559680000 rw-p 00018000 fe:00 123                        /lib/x86_64-linux-gnu/libgcc_s.so.1
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2559680000-7f25596a2000 r--p 00000000 fe:00 109                        /lib/x86_64-linux-gnu/libc-2.31.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25596a2000-7f25597fb000 r-xp 00022000 fe:00 109                        /lib/x86_64-linux-gnu/libc-2.31.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25597fb000-7f255984a000 r--p 0017b000 fe:00 109                        /lib/x86_64-linux-gnu/libc-2.31.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255984a000-7f255984e000 r--p 001c9000 fe:00 109                        /lib/x86_64-linux-gnu/libc-2.31.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255984e000-7f2559850000 rw-p 001cd000 fe:00 109                        /lib/x86_64-linux-gnu/libc-2.31.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2559850000-7f2559854000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2559854000-7f255985a000 r--p 00000000 fe:00 154                        /lib/x86_64-linux-gnu/libpthread-2.31.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255985a000-7f255986a000 r-xp 00006000 fe:00 154                        /lib/x86_64-linux-gnu/libpthread-2.31.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255986a000-7f2559870000 r--p 00016000 fe:00 154                        /lib/x86_64-linux-gnu/libpthread-2.31.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2559870000-7f2559871000 r--p 0001b000 fe:00 154                        /lib/x86_64-linux-gnu/libpthread-2.31.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2559871000-7f2559872000 rw-p 0001c000 fe:00 154                        /lib/x86_64-linux-gnu/libpthread-2.31.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2559872000-7f2559876000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2559876000-7f2559883000 r--p 00000000 fe:00 130                        /lib/x86_64-linux-gnu/libm-2.31.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f2559883000-7f255991d000 r-xp 0000d000 fe:00 130                        /lib/x86_64-linux-gnu/libm-2.31.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f255991d000-7f25599b8000 r--p 000a7000 fe:00 130                        /lib/x86_64-linux-gnu/libm-2.31.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25599b8000-7f25599b9000 r--p 00141000 fe:00 130                        /lib/x86_64-linux-gnu/libm-2.31.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25599b9000-7f25599ba000 rw-p 00142000 fe:00 130                        /lib/x86_64-linux-gnu/libm-2.31.so
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25599ba000-7f25599bc000 rw-p 00000000 00:00 0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25599bc000-7f25599be000 r--p 00000000 fe:00 116                        /lib/x86_64-linux-gnu/libcrypt.so.1.1.0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25599be000-7f25599d3000 r-xp 00002000 fe:00 116                        /lib/x86_64-linux-gnu/libcrypt.so.1.1.0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25599d3000-7f25599ed000 r--p 00017000 fe:00 116                        /lib/x86_64-linux-gnu/libcrypt.so.1.1.0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]7f25599ed000-7f25599ee000 r--p 00030000 fe:00 116                        /lib/x86_64-linux-gnu/libcrypt.so.1.1.0
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info] INFO Main child exited with signal (with signal 'SIGSEGV', core dumped? false)
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info] INFO Starting clean up.
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info] WARN hallpass exited, pid: 306, status: signal: 15 (SIGTERM)
2024-01-10T17:47:43Z app[148edd30c25d89] bog [info]2024/01/10 17:47:43 listening on [fdaa:0:5b8f:a7b:cf:97d4:923f:2]:22 (DNS: [fdaa::3]:53)
2024-01-10T17:47:44Z app[148edd30c25d89] bog [info][    2.264910] reboot: Restarting system
2024-01-10T17:47:44Z runner[148edd30c25d89] bog [info]machine has reached its max restart count (10)
```

All Ruby processes crash, even `ruby -e "puts 123"`

gdb output:
```
Thread 1 "ruby" received signal SIGSEGV, Segmentation fault.
redblack_new (right=0x0, left=0x0, value=0x7ffff5faf3e8, key=49891, color=1 '\001') at shape.c:149
149     shape.c: No such file or directory.
(gdb) bt
#0  redblack_new (right=0x0, left=0x0, value=0x7ffff5faf3e8, key=49891, color=1 '\001') at shape.c:149
#1  redblack_insert_aux (tree=<optimized out>, key=49891, value=value@entry=0x7ffff5faf3e8) at shape.c:247
#2  0x00007ffff7c33e4f in redblack_insert (value=0x7ffff5faf3e8, key=<optimized out>, tree=<optimized out>) at shape.c:287
#3  redblack_cache_ancestors (shape=0x7ffff5faf3e8) at shape.c:434
#4  0x00007ffff7c33e2d in redblack_cache_ancestors (shape=0x7ffff5faf410) at shape.c:431
#5  redblack_cache_ancestors (shape=0x7ffff5faf438) at shape.c:431
#6  0x00007ffff7c33e2d in redblack_cache_ancestors (shape=0x7ffff5faf460) at shape.c:431
#7  redblack_cache_ancestors (shape=0x7ffff5faf488) at shape.c:431
#8  0x00007ffff7c33e2d in redblack_cache_ancestors (shape=0x7ffff5faf4b0) at shape.c:431
#9  redblack_cache_ancestors (shape=0x7ffff5faf4d8) at shape.c:431
#10 0x00007ffff7c33e2d in redblack_cache_ancestors (shape=0x7ffff5faf500) at shape.c:431
#11 redblack_cache_ancestors (shape=0x7ffff5faf528) at shape.c:431
#12 0x00007ffff7c33e2d in redblack_cache_ancestors (shape=0x7ffff5faf550) at shape.c:431
#13 redblack_cache_ancestors (shape=0x7ffff5faf578) at shape.c:431
#14 0x00007ffff7c34db8 in rb_shape_alloc_new_child (shape_type=SHAPE_IVAR, shape=0x7ffff5faf550, id=49811) at shape.c:473
#15 get_next_shape_internal (new_variations_allowed=true, variation_created=<synthetic pointer>, shape_type=SHAPE_IVAR, id=49811, shape=0x7ffff5faf550) at shape.c:529
#16 rb_shape_get_next (shape=shape@entry=0x7ffff5faf550, obj=obj@entry=140737319960480, id=id@entry=49811) at shape.c:721
#17 0x00007ffff7caf7cf in general_ivar_set (too_complex_table_func=<optimized out>, transition_too_complex_func=<optimized out>, set_shape_func=<optimized out>, shape_resize_ivptr_func=<optimized out>, shape_ivptr_func=<optimized out>, data=0x0, val=140737289935680,
    id=49811, obj=140737319960480) at variable.c:1513
#18 rb_class_ivar_set (obj=obj@entry=140737319960480, id=id@entry=49811, val=val@entry=140737289935680) at variable.c:4236
#19 0x00007ffff7caf9a4 in ivar_set (val=140737289935680, id=49811, obj=140737319960480) at variable.c:1844
#20 ivar_set (val=140737289935680, id=49811, obj=140737319960480) at variable.c:1831
#21 rb_ivar_set (obj=140737319960480, id=49811, val=140737289935680) at variable.c:1857
#22 0x00007ffff7cccd1b in vm_setinstancevariable (ic=<optimized out>, val=<optimized out>, id=<optimized out>, obj=<optimized out>, iseq=<optimized out>) at vm_insnhelper.c:1639
#23 vm_exec_core (ec=0x55555555d9e0) at insns.def:227
#24 0x00007ffff7cd070a in rb_vm_exec (ec=0x55555555d9e0) at vm.c:2486
#25 0x00007ffff7cd15b0 in rb_iseq_eval (iseq=iseq@entry=0x7ffff42273a0) at vm.c:2741
#26 0x00007ffff7b5780d in load_iseq_eval (fname=140737289873720, ec=<optimized out>) at load.c:774
#27 require_internal (ec=0x55555555d9e0, fname=<optimized out>, exception=1, warn=<optimized out>) at load.c:1281
#28 0x00007ffff7b584f7 in rb_require_string_internal (resurrect=false, fname=140737289874680) at load.c:1380
#29 rb_require_string (fname=<optimized out>) at load.c:1373
#30 0x00007ffff7cb9d4d in vm_call_cfunc_with_frame_ (stack_bottom=<optimized out>, argv=<optimized out>, argc=<optimized out>, calling=<optimized out>, reg_cfp=<optimized out>, ec=<optimized out>) at vm_insnhelper.c:3490
#31 vm_call_cfunc_with_frame (calling=<optimized out>, reg_cfp=<optimized out>, ec=<optimized out>) at vm_insnhelper.c:3518
#32 vm_call_cfunc_other (ec=0x55555555d9e0, reg_cfp=0x7ffff752cfa0, calling=<optimized out>) at vm_insnhelper.c:3544
#33 0x00007ffff7cca80b in vm_sendish (method_explorer=<optimized out>, block_handler=<optimized out>, cd=<optimized out>, reg_cfp=<optimized out>, ec=<optimized out>) at vm_callinfo.h:408
#34 vm_exec_core (ec=0x55555555d9e0) at insns.def:834
#35 0x00007ffff7cd070a in rb_vm_exec (ec=0x55555555d9e0) at vm.c:2486
#36 0x00007ffff7c3007f in ruby_init_prelude () at ruby.c:1730
#37 ruby_opt_init (opt=0x7fffffffe5a0) at ruby.c:1791
#38 0x00007ffff7c30698 in ruby_opt_init (opt=0x7fffffffe5a0) at ruby.c:1749
#39 load_file_internal (argp_v=argp_v@entry=140737488343648) at ruby.c:2599
#40 0x00007ffff7af03b3 in rb_ensure (b_proc=b_proc@entry=0x7ffff7c30220 <load_file_internal>, data1=data1@entry=140737488343648, e_proc=e_proc@entry=0x7ffff7c2c600 <restore_load_file>, data2=data2@entry=140737488343648) at eval.c:1009
#41 0x00007ffff7c32171 in load_file (opt=0x7fffffffe5a0, script=1, f=140737320030480, fname=<optimized out>, parser=140737290171560) at ruby.c:2760
#42 process_options (argc=0, argv=0x7fffffffe870, opt=0x7fffffffe5a0) at ruby.c:2296
#43 0x00007ffff7c32882 in ruby_process_options (argc=argc@entry=1, argv=argv@entry=0x7fffffffe868) at ruby.c:229
#44 0x00007ffff7af148d in ruby_options (argc=argc@entry=1, argv=argv@entry=0x7fffffffe868) at eval.c:121
#45 0x000055555555510b in rb_main (argv=0x7fffffffe868, argc=1) at ./main.c:39
#46 main (argc=<optimized out>, argv=<optimized out>) at ./main.c:58
```

Build flags: `'--build=x86_64-linux-gnu' '--disable-install-doc' '--enable-shared' '--enable-yjit' 'build_alias=x86_64-linux-gnu'`